### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ jdk:
 matrix:
   include:
   - jdk: oraclejdk8
-script: travis_wait 30 mvn verify org.pitest:pitest-maven:mutationCoverage
+script: mvn verify org.pitest:pitest-maven:mutationCoverage
 notifications:
   slack:
     secure: Vcrg6S2F40pTLir+D4eegQINQm0UKSRdwU5gzXwzfUX4pGLWPv1NzExZb6S8LXXTNU7j5Udop/XelgBps4iverYeDlEOSe+Abr8i7YTBvz1oyRzVj02HMtiVykJ76NbaVsjpdFXacW24FLlApbBjDvCp1E1xnvdVs4CH8qlY8IQE9vJW0YQNi0umOMVGyrQoIDbKha9NT/d+/HGkxSUB7X6t5G5ZAUoJryJQ9bvJrx9Vx0KQdKjYTCpLKzKbXKEv+hYsuUEozUXKwDZM+Xvuf2j0tSiRUqE1g550eoO/gUjfjza4vMG2LKX7B+IP29VNc8wDW3dt373hnk6qTeaBZOFjnf/XXB3vbQeFydFO2wmtF0XY2R2xqr2or+M71s1BjU+/AbbI5NEm5jBWy6x+P2Mb4NXbJ3wxVBH2vkdKJ2LIZL3xQCa86lLsdbdlItdY38ZSbLRTTlt+fatFErfeqj1LfOQFpwbQSyffB475m5WhOZw+iG8oiyuo7MoGoupmP7eQtJGO60mfEP7aYImmxHrX6wYtkyU55TNfYXx7plfpFVU6JUiDmbwqmWptywnY5YcXeIdvnRSfsl0YwpCbeCl+hi6fOV31vIwMhYTUVjA39SznO5vV34R2ep61pxv51lQyGxA4OyKyBGs1H6gOTSuPkwlr2l7H09FohahsFV4=
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
